### PR TITLE
fixed errors

### DIFF
--- a/LightGame/Assets/Scripts/load.cs
+++ b/LightGame/Assets/Scripts/load.cs
@@ -12,6 +12,7 @@ public class load : MonoBehaviour {
 	public ArrayList scores = new ArrayList();
 
 	//3Dtext for levels in World1 scene
+	public bool level1 = false;
 	public bool level2 = false;
 
 	//3Dtext for scores in scores scene
@@ -36,7 +37,27 @@ public class load : MonoBehaviour {
 	void Update () {
 
 	}
-
+	
+	
+	
+void OnMouseUp()
+    {
+        // no restrictions on level 1
+        //level1 is loaded
+        if (level1 == true)
+        {
+            Application.LoadLevel("Level1");
+        }
+        //checks if the level is unlocked and finished
+        // if true level2 is loaded
+        if (level2 == true && levels.Contains(2) == true && levels.Contains(1))
+        {
+            //when level 2 is added uncomment the the line below 
+            //Application.LoadLevel("Level2");
+        }
+    }
+	
+	
 	
 	IEnumerator get_records_by_email(string user_email) {
 		levels.Clear();


### PR DESCRIPTION
@NadineMansour @MMelouk94 @alisoliman @mohamadbadr 

my external documentation :

```
A box collider for all levels is created. *If the level is pressed it will be checked if it's unlocked and if it is 
```

finished , if this is true the level will be loaded , otherwise the icon will be changed to LOCKED.

![doc 1](https://cloud.githubusercontent.com/assets/10845554/6729827/00cb3ae2-ce3f-11e4-960e-81c08b07148f.png)
